### PR TITLE
Test if WordPress_SimpleSettings has already been defined

### DIFF
--- a/examples/awesome-plugin/awesome-plugin.php
+++ b/examples/awesome-plugin/awesome-plugin.php
@@ -7,7 +7,9 @@ Author: Clif Griffin Development Inc.
 Author URI: http://cgd.io
 */
 
-require('inc/wordpress-simple-settings.php'); // include the framework
+// Include the framework only if another plugin has not already done so
+if ( ! class_exists('WordPress_SimpleSettings') )
+	require('inc/wordpress-simple-settings.php'); 
 
 class AwesomePlugin extends WordPress_SimpleSettings {
 	var $prefix = 'awesome'; // this is super recommended


### PR DESCRIPTION
Test if WordPress_SimpleSettings has already been defined before loading class definition (in case multiple plugins all use this and have their own copy)
